### PR TITLE
Update README.md re: how WebDB handles writability

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ Once your query has been defined, you can execute and *modify* the results using
   - [put(record)](#queryputrecord)
   - [update(updates)](#queryupdateupdates)
   - [update(fn)](#queryupdatefn)
+  
+If you try to modify rows in archives that are not writable, WebDB will throw an error.
 
 ### Table helper methods
 


### PR DESCRIPTION
I was wondering about how WebDB handled archives that weren't writable by the user, so I added a line to the README answering the question.