### PR TITLE
pass options through to DatArchive; update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -668,19 +668,22 @@ await webdb.indexArchive('dat://foo.com')
  - `url` String or DatArchive or Array&lt;String or DatArchive&gt;. The sites to index.
  - `opts` Object.
    - `watch` Boolean. Should WebDB watch the archive for changes, and index them immediately? Defaults to true.
+   - `dat`: Object. Passed through as options to DatArchive.
  - Returns Promise&lt;Void&gt;.
 
 Add one or more dat:// sites to be indexed.
 The method will return when the site has been fully indexed.
 This will add the given archive to the "sources" list.
 
-### webdb.unindexArchive(url)
+### webdb.unindexArchive(url[, opts])
 
 ```js
 await webdb.unindexArchive('dat://foo.com')
 ```
 
  - `url` String or DatArchive. The site to deindex.
+ - `opts` Object.
+   - `dat`: Object. Passed through as options to DatArchive.
  - Returns Promise&lt;Void&gt;.
 
 Remove a dat:// site from the dataset.

--- a/index.js
+++ b/index.js
@@ -149,7 +149,7 @@ class WebDB extends EventEmitter {
     }
 
     // create our own new DatArchive instance
-    archive = typeof archive === 'string' ? new (this.DatArchive)(archive) : archive
+    archive = typeof archive === 'string' ? new (this.DatArchive)(archive, opts.dat) : archive
     if (!(archive.url in this._archives)) {
       // store and process
       debug('WebDB.indexArchive', archive.url)
@@ -158,8 +158,8 @@ class WebDB extends EventEmitter {
     }
   }
 
-  async unindexArchive (archive) {
-    archive = typeof archive === 'string' ? new (this.DatArchive)(archive) : archive
+  async unindexArchive (archive, opts = {}) {
+    archive = typeof archive === 'string' ? new (this.DatArchive)(archive, opts.dat) : archive
     if (archive.url in this._archives) {
       debug('WebDB.unindexArchive', archive.url)
       delete this._archives[archive.url]


### PR DESCRIPTION
Addresses issue https://github.com/beakerbrowser/webdb/issues/13 by passing the `dat` attribute of the `opts` parameter of `indexArchive` and `unindexArchive` to DatArchive as its second parameter. I've also updated the README to reflect this change.