### PR TITLE
Replacing createFileActivityStream with watch

### DIFF
--- a/lib/indexer.js
+++ b/lib/indexer.js
@@ -43,7 +43,7 @@ exports.watchArchive = async function (db, archive) {
     // -prf
     await archive._loadPromise
   }
-  archive.fileEvents = archive.createFileActivityStream(db._tableFilePatterns)
+  archive.fileEvents = archive.watch(db._tableFilePatterns)
   // autodownload all changes to the watched files
   archive.fileEvents.addEventListener('invalidated', ({path}) => archive.download(path))
   // autoindex on changes


### PR DESCRIPTION
Some housekeeping to `update createFileActivityStream` to `watch` and get rid of the deprication warnings in console.