### PR TITLE
Preventing indexer from running through all metadata on an initial index.

### DIFF
--- a/lib/indexer.js
+++ b/lib/indexer.js
@@ -108,7 +108,7 @@ async function indexArchive (db, archive) {
       db._indexMetaLevel.get(archive.url).catch(e => null),
       archive.getInfo()
     ])
-    indexMeta = indexMeta || {version: 0}
+    indexMeta = indexMeta || {version: archiveMeta.version - 1}
 
     // has this version of the archive been processed?
     if (indexMeta && indexMeta.version >= archiveMeta.version) {

--- a/lib/indexer.js
+++ b/lib/indexer.js
@@ -108,7 +108,7 @@ async function indexArchive (db, archive) {
       db._indexMetaLevel.get(archive.url).catch(e => null),
       archive.getInfo()
     ])
-    indexMeta = indexMeta || {version: archiveMeta.version - 1}
+    indexMeta = indexMeta || {version: 0}
 
     // has this version of the archive been processed?
     if (indexMeta && indexMeta.version >= archiveMeta.version) {
@@ -118,11 +118,17 @@ async function indexArchive (db, archive) {
     }
     debug('Indexer.indexArchive', archive.url, 'start', indexMeta.version, 'end', archiveMeta.version)
 
+    // if this is the first run index all matched files, otherwise
     // find and apply all changes which haven't yet been processed
-    var updates = await scanArchiveHistoryForUpdates(db, archive, {
-      start: indexMeta.version + 1,
-      end: archiveMeta.version + 1
-    })
+    var updates = {}
+    if (indexMeta && indexMeta.version === 0) {
+      updates = await scanArchiveForFirstIndex(db, archive)
+    } else {
+      updates = await scanArchiveHistoryForUpdates(db, archive, {
+        start: indexMeta.version + 1,
+        end: archiveMeta.version + 1
+      })
+    }
     await applyUpdates(db, archive, updates)
     debug('Indexer.indexArchive applied', updates.length, 'updates from', archive.url)
 
@@ -282,6 +288,27 @@ async function scanArchiveHistoryForUpdates (db, archive, {start, end}) {
 
   // return an array ordered by version
   return Object.values(updates).sort((a, b) => a.version - b.version)
+}
+
+// recursively pull file listing for archive
+// match against the tables' path patterns
+// return back each matching record, as an array
+async function scanArchiveForFirstIndex  (db, archive) {
+  var allFiles = await archive.readdir('/', {recursive: true})
+  var archiveInfo = await archive.getInfo()
+
+  var updates = {}
+  allFiles.forEach(file => {
+    var path = '/' + file
+    if (anymatch(db._tableFilePatterns, path)) {
+      updates[path] = {
+        path: path,
+        version: archiveInfo.version
+      }
+    }
+  })
+
+  return Object.values(updates)
 }
 
 // look through the archive for any files that generate records


### PR DESCRIPTION
I've encountered trouble with WebDB when trying to index archives that have very large amounts of metadata.  The operation will either time-out repeatedly until it eventually succeeds in downloading all metadata (after many minutes), or it will outright fail and never index the archive.  This is especially pronounced when using the
```
await webdb.delete()
await webdb.open()
```
technique to clear the database before indexing.

As it stands the indexer compares the indexMeta version and the archiveMeta version and then tries to roll through the gap applying the changes recorded in the archives history.  In most cases this is wanted, especially if you are trying to preserve a previously indexed db.  However, in the case of an initial indexing or when using the above destroy then index technique, I don't think it is necessary and causes problems with archives that have a lot of history.  (For example an indexMeta version of 0 and an archiveMeta version of tens of thousands.)  In these initial index cases, I think it makes sense to only index the most recent changes to the archive (its current state) and then continue on from there.  This is facilitated in this PR by setting the indexMeta version 1 behind the current archiveMeta version when it is seen that indexMeta is falsey.  I've tested this on an archive with > 100MB of metadata and it seems to work well, immediately indexing on the latest archive version, then continuing on as normal for subsiquent archive updates.

My concern is that this will disallow any kind of rollback through an archives history (via the indexed db) that occured before the initial indexing. However, from what I can tell, this does not seem to be a use case for WebDB, and the API does not seem to expose any querying on histories.

Anyway, this PR may be way off base or premature, but its been working well for me so I thought I'd put it out there.