### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1115,7 +1115,7 @@ The schema definition for the table.
 var records = await webdb.mytable.toArray()
 ```
 
- - Returns Promise&lt;Array&gt;.
+ - Returns Promise&lt;Array&lt;Object&gt;&gt;.
 
 Returns an array of all records in the table.
 


### PR DESCRIPTION
Add Array type specification (i.e. use Array\<Object\> instead of Array)